### PR TITLE
uboot-mtk-20220606: arm: Only support ARM64_CRC32 when using GCC

### DIFF
--- a/uboot-mtk-20220606/arch/arm/Kconfig
+++ b/uboot-mtk-20220606/arch/arm/Kconfig
@@ -12,7 +12,7 @@ config ARM64
 
 config ARM64_CRC32
 	bool "Enable support for CRC32 instruction"
-	depends on ARM64
+	depends on ARM64 && CC_IS_GCC
 	default y
 	help
 	  ARMv8 implements dedicated crc32 instruction for crc32 calculation.


### PR DESCRIPTION
Today, only gcc has __builtin_aarch64_crc32b (clang-16 does not, for
example). Make this option depend on CC_IS_GCC.
