### PR TITLE
uboot-202206: mt7986/bootmenu_emmc: sync write firmware logic from 7981

### DIFF
--- a/uboot-mtk-20220606/board/mediatek/mt7986/bootmenu_emmc.c
+++ b/uboot-mtk-20220606/board/mediatek/mt7986/bootmenu_emmc.c
@@ -140,8 +140,7 @@ int write_firmware(void *priv, const struct data_part_entry *dpe,
 	const void *kernel_data, *rootfs_data;
 	size_t kernel_size, rootfs_size;
 	loff_t rootfs_data_offs;
-	int ret = 0, ret2 = 0;
-
+	int ret = 0;
 #ifdef CONFIG_MTK_DUAL_BOOT
 	u32 slot;
 #endif /* CONFIG_MTK_DUAL_BOOT */
@@ -162,18 +161,16 @@ int write_firmware(void *priv, const struct data_part_entry *dpe,
 	rootfs_part = PART_ROOTFS_NAME;
 #endif /* CONFIG_MTK_DUAL_BOOT */
 
+	ret = write_part(rootfs_part, rootfs_data, rootfs_size, true);
+	if (ret)
+		return ret;
+
+	/* Mark rootfs_data unavailable */
+	rootfs_data_offs = (rootfs_size + ROOTDEV_OVERLAY_ALIGN - 1) &
+			   (~(ROOTDEV_OVERLAY_ALIGN - 1));
+	erase_part(PART_ROOTFS_NAME, rootfs_data_offs, SZ_512K);
+
 	ret = write_part(kernel_part, kernel_data, kernel_size, true);
-	ret2 = write_part(rootfs_part, rootfs_data, rootfs_size, true);
-
-	if (!ret2) {
-		/* Mark rootfs_data unavailable */
-		rootfs_data_offs = (rootfs_size + ROOTDEV_OVERLAY_ALIGN - 1) &
-				   (~(ROOTDEV_OVERLAY_ALIGN - 1));
-		erase_part(PART_ROOTFS_NAME, rootfs_data_offs, SZ_512K);
-	} else {
-		ret = ret2;
-	}
-
 	if (ret)
 		return ret;
 
@@ -270,7 +267,6 @@ int board_boot_default(void)
 	mbd.boot_slots = dual_boot_slots;
 	mbd.env_part = ofnode_conf_read_str("u-boot,mmc-env-partition");
 	mbd.load_ptr = (void *)0x40000000;
-
 #ifdef CONFIG_MTK_DUAL_BOOT_SHARED_ROOTFS_DATA
 	mbd.rootfs_data_part = CONFIG_MTK_DUAL_BOOT_ROOTFS_DATA_NAME;
 #endif


### PR DESCRIPTION
The [mt7981/bootmenu_emmc.c](https://github.com/lgs2007m/bl-mt798x/commit/61c245c0882db12feb4eabac26c04186fd426c08#diff-e188e5da0317a38010c421a227f8ed8d60839c603586fca88e5a0747860cc3e0R164) has already synchronized the write firmware logic from [uboot-202307/mmc_helper.c](https://github.com/hanwckf/bl-mt798x/blob/master/uboot-mtk-20230718-09eda825/board/mediatek/common/mmc_helper.c#L999) by [Tianling Shen](https://github.com/1715173329).  
Due to the shared logic between mt7981 and mt7986, I replaced mt7986/bootmenu_emmc.c with mt7981/bootmenu_emmc.c for code consistency.