### PR TITLE
add support for failsafe boot via env

### DIFF
--- a/uboot-mtk-20220606/common/main.c
+++ b/uboot-mtk-20220606/common/main.c
@@ -60,6 +60,14 @@ void main_loop(void)
 			efi_launch_capsules();
 	}
 
+	if (env_get("failsafe") != NULL) {
+		env_set("failsafe", NULL);
+		env_save();
+
+		led_control("led", "system_led", "on");
+		run_command("httpd", 0);
+	}
+
 	run_command("glbtn", 0);
 
 	s = bootdelay_process();

--- a/uboot-mtk-20230718-09eda825/common/main.c
+++ b/uboot-mtk-20230718-09eda825/common/main.c
@@ -61,6 +61,14 @@ void main_loop(void)
 			efi_launch_capsules();
 	}
 
+	if (env_get("failsafe") != NULL) {
+		env_set("failsafe", NULL);
+		env_save();
+
+		led_control("led", "system_led", "on");
+		run_command("httpd", 0);
+	}
+
 	run_command("glbtn", 0);
 
 	s = bootdelay_process();


### PR DESCRIPTION
To use it in openwrt, run: fw_setenv failsafe 1

This allows booting to uboot web failsafe mode without pressing the reset button.