### PR TITLE
Add GitHub Action CI build

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,55 @@
+name: Uboot Ubuntu CI Build
+run-name: Uboot - ${{ inputs.board }} (${{ inputs.soc }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      soc:
+        required: true
+        description: SOC/CPU Model
+        type: string
+        default: mt7981
+      board:
+        required: true
+        description: Router Model Name
+        type: string
+        default: ax3000t
+      multi-layout:
+        required: true
+        description: Enable Multiple Flash Layout Support
+        type: choice
+        default: '1'
+        options:
+          - '0'
+          - '1'
+      runs-on:
+        required: true
+        description: Runs on...
+        type: choice
+        default: ubuntu-latest
+        options:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-latest
+
+jobs:
+  ubuntu-build:
+    name: Build on ${{ inputs.runs-on }}
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get build dept.
+        run: |
+          sudo apt update
+          sudo apt install gcc-aarch64-linux-gnu build-essential flex bison libssl-dev
+      - name: Build it
+        run: |
+          ./build.sh
+        env:
+          SOC: ${{ inputs.soc }}
+          BOARD: ${{ inputs.board }}
+          MULTI_LAYOUT: ${{ inputs.multi-layout }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Uboot - ${{ inputs.board }} (${{ inputs.soc }})
+          path: output/*.bin


### PR DESCRIPTION
After this, one can simply fork the repo and use GitHub Action to trigger a build for their own device. Once the build finished, they can get the binary from the artifacts list of that CI run.

I'm upstreaming this GitHub Action workflow hopefully it can help others get better use of this project.

Some screenshots for people who are not familiar with GitHub Action, about how to use it:

![image](https://github.com/user-attachments/assets/6ab5a536-cb38-46d3-b8c3-49a635ed326e)

![image](https://github.com/user-attachments/assets/7cf3ebf7-c97e-4a05-82da-830abb8bf4e7)
