### PR TITLE
uboot: failsafe: support boot into initramfs

### DIFF
--- a/uboot-mtk-20220606/failsafe/fsdata/booting.html
+++ b/uboot-mtk-20220606/failsafe/fsdata/booting.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>Booting initramfs</title>
+		<link rel="stylesheet" href="/style.css">
+		<script src="/index.js"></script>
+		<script>
+			function init() {
+				getversion();
+
+				ajax({
+					url: '/result',
+					done: function(response) {
+						if (response == 'failed') {
+							location = '/fail.html'
+							return
+						}
+
+						document.getElementById('title').innerHTML = 'BOOT SUCCESS'
+						document.getElementById('info').innerHTML = 'Your device was successfully booted into initramfs!'
+					},
+					timeout: 30000
+				})
+
+				ajax('/result', function(response) {
+					if (response == 'failed') {
+						location = '/fail.html'
+						return
+					}
+
+					document.getElementById('title').innerHTML = 'BOOT SUCCESS'
+					document.getElementById('info').innerHTML = 'Your device was successfully booted into initramfs!'
+				}, 30000)
+			}
+		</script>
+	</head>
+	<body onload="init()">
+		<div id="m">
+			<h1 id="title">BOOTING INITRAMFS</h1>
+			<p id="info">
+				Your file was successfully uploaded! Booting is in progress, please wait...<br>
+				This page may be in not responding status for a short time.
+			</p>
+			<div id="l"></div>
+		</div>
+		<div id="version"></div>
+	</body>
+</html>

--- a/uboot-mtk-20220606/failsafe/fsdata/initramfs.html
+++ b/uboot-mtk-20220606/failsafe/fsdata/initramfs.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>Load initramfs</title>
+		<link rel="stylesheet" href="/style.css">
+		<script src="/index.js"></script>
+	</head>
+	<body onload="startup()">
+		<div id="m">
+			<h1>LOAD INITRAMFS</h1>
+			<p id="hint">
+				You are going to load <strong>initramfs</strong> on the device.<br>
+				Please, choose file from your local hard drive and click <strong>Upload</strong> button.
+			</p>
+			<form id="form">
+				<input id="file" type="file" name="initramfs">
+				<input type="button" value="Upload" onclick="upload('initramfs')">
+			</form>
+			<div>
+				<div class="bar" id="bar" style="display: none; --percent: 0;"></div>
+			</div>
+			<div id="size" style="display: none;">Size: xxxx</div>
+			<div id="md5" style="display: none;">MD5: xxxx</div>
+			<div id="upgrade" style="display: none;">
+				<p>If all information above is correct, click "Boot".</p>
+				<button class="button" onclick="location = '/booting.html'">Boot</button>
+			</div>
+			<div class="i w">
+				<strong>WARNINGS</strong>
+				<ul>
+					<li>if everything goes well, the device will boot into the initramfs</li>
+					<li>you can upload whatever you want, so be sure that you choose proper initramfs image for your device</li>
+				</ul>
+			</div>
+		</div>
+		<div id="version"></div>
+	</body>
+</html>

--- a/uboot-mtk-20230718-09eda825/failsafe/fsdata/Makefile
+++ b/uboot-mtk-20230718-09eda825/failsafe/fsdata/Makefile
@@ -5,41 +5,49 @@
 # FILE_XXXX.o := YYYY.html <- actual html file to be embedded
 # FSPATH_XXXX.o := ZZZ/WWW.EXT <- virtual fs path to be used inside u-boot
 
-obj-y += index.o
-FILE_index.o := index.html
-FSPATH_index.o := index.html
-
-obj-y += main.o
-FILE_main.o := main.js
-FSPATH_main.o := main.js
-
-obj-y += flashing.o
-FILE_flashing.o := flashing.html
-FSPATH_flashing.o := flashing.html
-
-obj-y += fail.o
-FILE_fail.o := fail.html
-FSPATH_fail.o := fail.html
-
 obj-y += 404.o
 FILE_404.o := 404.html
 FSPATH_404.o := 404.html
-
-obj-y += uboot.o
-FILE_uboot.o := uboot.html
-FSPATH_uboot.o := uboot.html
 
 obj-y += bl2.o
 FILE_bl2.o := bl2.html
 FSPATH_bl2.o := bl2.html
 
+obj-y += booting.o
+FILE_booting.o := booting.html
+FSPATH_booting.o := booting.html
+
+obj-y += fail.o
+FILE_fail.o := fail.html
+FSPATH_fail.o := fail.html
+
+obj-y += flashing.o
+FILE_flashing.o := flashing.html
+FSPATH_flashing.o := flashing.html
+
 obj-y += gpt.o
 FILE_gpt.o := gpt.html
 FSPATH_gpt.o := gpt.html
 
+obj-y += index.o
+FILE_index.o := index.html
+FSPATH_index.o := index.html
+
+obj-y += initramfs.o
+FILE_initramfs.o := initramfs.html
+FSPATH_initramfs.o := initramfs.html
+
+obj-y += main.o
+FILE_main.o := main.js
+FSPATH_main.o := main.js
+
 obj-y += style.o
 FILE_style.o := style.css
 FSPATH_style.o := style.css
+
+obj-y += uboot.o
+FILE_uboot.o := uboot.html
+FSPATH_uboot.o := uboot.html
 
 # customized build rules
 strip_path = $(subst /,_,$(subst -,_,$(subst .,_,$(1))))

--- a/uboot-mtk-20230718-09eda825/failsafe/fsdata/booting.html
+++ b/uboot-mtk-20230718-09eda825/failsafe/fsdata/booting.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>Booting initramfs</title>
+		<link rel="stylesheet" href="/style.css">
+		<script src="/main.js"></script>
+		<script>
+			function init() {
+				getversion();
+
+				ajax({
+					url: '/result',
+					done: function(response) {
+						if (response == 'failed') {
+							location = '/fail.html'
+							return
+						}
+
+						document.getElementById('title').innerHTML = 'BOOT SUCCESS'
+						document.getElementById('info').innerHTML = 'Your device was successfully booted into initramfs!'
+					},
+					timeout: 30000
+				})
+			}
+		</script>
+	</head>
+	<body onload="init()">
+		<div id="m">
+			<h1 id="title">BOOTING INITRAMFS</h1>
+			<p id="info">
+				Your file was successfully uploaded! Booting is in progress, please wait...<br>
+				This page may be in not responding status for a short time.
+			</p>
+			<div id="l"></div>
+		</div>
+		<div id="version"></div>
+	</body>
+</html>

--- a/uboot-mtk-20230718-09eda825/failsafe/fsdata/initramfs.html
+++ b/uboot-mtk-20230718-09eda825/failsafe/fsdata/initramfs.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>Load initramfs</title>
+		<link rel="stylesheet" href="/style.css">
+		<script src="/main.js"></script>
+	</head>
+	<body onload="startup()">
+		<div id="m">
+			<h1>LOAD INITRAMFS</h1>
+			<p id="hint">
+				You are going to load <strong>initramfs</strong> on the device.<br>
+				Please, choose file from your local hard drive and click <strong>Upload</strong> button.
+			</p>
+			<form id="form">
+				<input id="file" type="file" name="initramfs">
+				<input type="button" value="Upload" onclick="upload('initramfs')">
+			</form>
+			<div>
+				<div class="bar" id="bar" style="display: none; --percent: 0;"></div>
+			</div>
+			<div id="size" style="display: none;">Size: xxxx</div>
+			<div id="md5" style="display: none;">MD5: xxxx</div>
+			<div id="upgrade" style="display: none;">
+				<p>If all information above is correct, click "Boot".</p>
+				<button class="button" onclick="location = '/booting.html'">Boot</button>
+			</div>
+			<div class="i w">
+				<strong>WARNINGS</strong>
+				<ul>
+					<li>if everything goes well, the device will boot into the initramfs</li>
+					<li>you can upload whatever you want, so be sure that you choose proper initramfs image for your device</li>
+				</ul>
+			</div>
+		</div>
+		<div id="version"></div>
+	</body>
+</html>

--- a/uboot-mtk-20230718-09eda825/include/failsafe/fw_type.h
+++ b/uboot-mtk-20230718-09eda825/include/failsafe/fw_type.h
@@ -8,6 +8,7 @@ typedef enum {
 	FW_TYPE_BL2,
 	FW_TYPE_FIP,
 	FW_TYPE_FW,
+	FW_TYPE_INITRD,
 } failsafe_fw_t;
 
 #endif


### PR DESCRIPTION
sort uri handlers while at it.
- - -

When testing on U-Boot 2023.07, I found a strange issue on CMCC RAX3000M eMMC board which failed to boot into its initramfs, while other images are fine. This issue only appeared in this version, I have no idea why.

```console
## Loading kernel from FIT Image at 440000d4 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.6.50
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x440001bc
     Data Size:    5583486 Bytes = 5.3 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x44000000
     Entry Point:  0x44000000
     Hash algo:    crc32
     Hash value:   8a170c4c
     Hash algo:    sha1
     Hash value:   4dcc2d3939c7bbacc5c7c1fb7b39f508eb8f481f
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading ramdisk from FIT Image at 440000d4 ...
   Using 'config-1' configuration
   Trying 'initrd-1' ramdisk subimage
     Description:  ARM64 OpenWrt cmcc_rax3000m initrd
     Type:         RAMDisk Image
     Compression:  uncompressed
     Data Start:   0x44553574
     Data Size:    7517088 Bytes = 7.2 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: unavailable
     Entry Point:  unavailable
     Hash algo:    crc32
     Hash value:   c4b0b0e1
     Hash algo:    sha1
     Hash value:   d9e803070304069db0d7bd75b32662f1dc986a65
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 440000d4 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt cmcc_rax3000m device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x44c7ea20
     Data Size:    24912 Bytes = 24.3 KiB
     Architecture: AArch64
     Load Address: 0x43f00000
     Hash algo:    crc32
     Hash value:   550473af
     Hash algo:    sha1
     Hash value:   5dab832b0fad3f30cd750f090bbfcd0c6edc073c
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Loading fdt from 0x44c7ea20 to 0x43f00000
## Loading fdt from FIT Image at 440000d4 ...
   Using 'mt7981b-cmcc-rax3000m-emmc' configuration
   Trying 'fdt-mt7981b-cmcc-rax3000m-emmc' fdt subimage
     Description:  ARM64 OpenWrt cmcc_rax3000m device tree overlay mt7981b-cmcc-rax3000m-emmc
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x44c84cc0
     Data Size:    3050 Bytes = 3 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   0846e2e7
     Hash algo:    sha1
     Hash value:   d2ff0eb8d6ab1d01985620614801f68d57dfc6a8
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x43f00000
Working FDT set to 43f00000
   Uncompressing Kernel Image
lzma compressed: uncompress error 1
Must RESET board to recover
resetting ...
```