### PR TITLE
uboot: refine fit ubootenv creation

### DIFF
--- a/uboot-mtk-20220606/board/mediatek/common/ubi_helper.c
+++ b/uboot-mtk-20220606/board/mediatek/common/ubi_helper.c
@@ -531,13 +531,16 @@ static int write_ubi_fit_image(const void *data, size_t size,
 		if (ret)
 			return ret;
 
-		ret = create_ubi_volume("ubootenv", 0x100000, -1, false);
+#ifdef CONFIG_ENV_IS_IN_UBI
+		ret = create_ubi_volume(CONFIG_ENV_UBI_VOLUME, CONFIG_ENV_SIZE, -1, false);
 		if (ret)
 			goto out;
-
-		ret = create_ubi_volume("ubootenv2", 0x100000, -1, false);
+#ifdef CONFIG_SYS_REDUNDAND_ENVIRONMENT
+		ret = create_ubi_volume(CONFIG_ENV_UBI_VOLUME_REDUND, CONFIG_ENV_SIZE, -1, false);
 		if (ret)
 			goto out;
+#endif
+#endif
 	}
 
 	/* Remove this volume first in case of no enough PEBs */

--- a/uboot-mtk-20230718-09eda825/board/mediatek/common/bootmenu_mtd.c
+++ b/uboot-mtk-20230718-09eda825/board/mediatek/common/bootmenu_mtd.c
@@ -24,6 +24,7 @@
 #else
  #define UBI_VID_OFFSET QUOTE(CONFIG_ENV_UBI_VID_OFFSET)
 #endif
+int env_ubi_erase(void);
 #endif /* CONFIG_ENV_IS_IN_UBI */
 
 static struct mtd_info *get_mtd_part(const char *partname)
@@ -330,8 +331,7 @@ static int erase_env(void *priv, const struct data_part_entry *dpe,
 	if (ubi_part(CONFIG_ENV_UBI_PART, UBI_VID_OFFSET))
 		return -EIO;
 
-	ubi_remove_vol(CONFIG_ENV_UBI_VOLUME);
-	create_ubi_volume(CONFIG_ENV_UBI_VOLUME, CONFIG_ENV_SIZE, UBI_VID_OFFSET, false);
+	env_ubi_erase();
 	ubi_exit();
 #else
 	struct mtd_info *mtd;

--- a/uboot-mtk-20230718-09eda825/board/mediatek/common/mtd_helper.c
+++ b/uboot-mtk-20230718-09eda825/board/mediatek/common/mtd_helper.c
@@ -655,13 +655,17 @@ static int write_ubi_fit_image(const void *data, size_t size,
 		if (ret)
 			return ret;
 
-		ret = create_ubi_volume("ubootenv", 0x100000, -1, false);
+#ifdef CONFIG_ENV_IS_IN_UBI
+		ret = create_ubi_volume(CONFIG_ENV_UBI_VOLUME, CONFIG_ENV_SIZE, UBI_VOL_NUM_AUTO, false);
 		if (ret)
 			goto out;
 
-		ret = create_ubi_volume("ubootenv2", 0x100000, -1, false);
+#ifdef CONFIG_SYS_REDUNDAND_ENVIRONMENT
+		ret = create_ubi_volume(CONFIG_ENV_UBI_VOLUME_REDUND, CONFIG_ENV_SIZE, UBI_VOL_NUM_AUTO, false);
 		if (ret)
 			goto out;
+#endif
+#endif
 	}
 
 	/* Remove this volume first in case of no enough PEBs */

--- a/uboot-mtk-20230718-09eda825/env/ubi.c
+++ b/uboot-mtk-20230718-09eda825/env/ubi.c
@@ -203,7 +203,7 @@ static int env_ubi_load(void)
 }
 #endif /* CONFIG_SYS_REDUNDAND_ENVIRONMENT */
 
-static int env_ubi_erase(void)
+int env_ubi_erase(void)
 {
 	ALLOC_CACHE_ALIGN_BUFFER(char, env_buf, CONFIG_ENV_SIZE);
 	int ret = 0;


### PR DESCRIPTION
Though we expect ubootenv and ubootenv2 in ubi, let's respect uboot config.