### PR TITLE
uboot: boot_helper: increase bootcmd length to 128 chars

### DIFF
--- a/uboot-mtk-20220606/board/mediatek/common/boot_helper.c
+++ b/uboot-mtk-20220606/board/mediatek/common/boot_helper.c
@@ -24,7 +24,7 @@
 
 int boot_from_mem(ulong data_load_addr)
 {
-	char cmd[64];
+	char cmd[128];
 	const char *bootconf = env_get("bootconf");
 
 	if (bootconf && strlen(bootconf) > 0)

--- a/uboot-mtk-20230718-09eda825/board/mediatek/common/boot_helper.c
+++ b/uboot-mtk-20230718-09eda825/board/mediatek/common/boot_helper.c
@@ -21,7 +21,7 @@
 
 int boot_from_mem(ulong data_load_addr)
 {
-	char cmd[64];
+	char cmd[128];
 	const char *bootconf = env_get("bootconf");
 
 	if (bootconf && strlen(bootconf) > 0)


### PR DESCRIPTION
64 chars are not enough for some images like bpi r3 and r3 mini.