### PR TITLE
uboot: fix build without glbtn and httpd

### DIFF
--- a/uboot-mtk-20220606/common/main.c
+++ b/uboot-mtk-20220606/common/main.c
@@ -62,15 +62,21 @@ void main_loop(void)
 			efi_launch_capsules();
 	}
 
+#ifdef CONFIG_HTTPD
 	if (env_get("failsafe") != NULL) {
 		env_set("failsafe", NULL);
 		env_save();
 
+#ifdef CONFIG_CMD_GL_BTN
 		led_control("led", "system_led", "on");
+#endif /* CONFIG_CMD_GL_BTN */
 		run_command("httpd", 0);
 	}
+#endif /* CONFIG_HTTPD */
 
+#ifdef CONFIG_CMD_GL_BTN
 	run_command("glbtn", 0);
+#endif
 
 	s = bootdelay_process();
 	if (cli_process_fdt(&s))

--- a/uboot-mtk-20220606/common/main.c
+++ b/uboot-mtk-20220606/common/main.c
@@ -13,12 +13,13 @@
 #include <command.h>
 #include <console.h>
 #include <env.h>
+#ifdef CONFIG_CMD_GL_BTN
+#include <glbtn.h>
+#endif
 #include <init.h>
 #include <net.h>
 #include <version_string.h>
 #include <efi_loader.h>
-
-void led_control(const char *cmd, const char *name, const char *arg);
 
 static void run_preboot_environment_command(void)
 {

--- a/uboot-mtk-20220606/failsafe/failsafe.c
+++ b/uboot-mtk-20220606/failsafe/failsafe.c
@@ -12,6 +12,9 @@
 #include <malloc.h>
 #include <command.h>
 #include <env.h>
+#ifdef CONFIG_CMD_GL_BTN
+#include <glbtn.h>
+#endif
 #include <net/tcp.h>
 #include <net/httpd.h>
 #include <u-boot/md5.h>
@@ -21,8 +24,6 @@
 
 #include "../board/mediatek/common/boot_helper.h"
 #include "fs.h"
-
-void led_control(const char *cmd, const char *name, const char *arg);
 
 enum {
 	FW_TYPE_GPT,

--- a/uboot-mtk-20220606/include/glbtn.h
+++ b/uboot-mtk-20220606/include/glbtn.h
@@ -1,0 +1,6 @@
+#ifndef _GLBTN_H_
+#define _GLBTN_H_
+
+void led_control(const char *cmd, const char *name, const char *arg);
+
+#endif

--- a/uboot-mtk-20220606/net/httpd.c
+++ b/uboot-mtk-20220606/net/httpd.c
@@ -15,8 +15,9 @@
 #include <net/tcp.h>
 #include <net/httpd.h>
 #include <command.h>
-
-void led_control(const char *cmd, const char *name, const char *arg);
+#ifdef CONFIG_CMD_GL_BTN
+#include <glbtn.h>
+#endif
 
 struct httpd_instance {
 	struct list_head node;

--- a/uboot-mtk-20230718-09eda825/board/mediatek/common/failsafe.c
+++ b/uboot-mtk-20230718-09eda825/board/mediatek/common/failsafe.c
@@ -12,12 +12,13 @@
 #include <linux/string.h>
 #include <asm/global_data.h>
 #include <failsafe/fw_type.h>
+#ifdef CONFIG_CMD_GL_BTN
+#include <glbtn.h>
+#endif
 #include "upgrade_helper.h"
 #include "colored_print.h"
 
 DECLARE_GLOBAL_DATA_PTR;
-
-void led_control(const char *cmd, const char *name, const char *arg);
 
 const char *fw_to_part_name(failsafe_fw_t fw)
 {

--- a/uboot-mtk-20230718-09eda825/common/main.c
+++ b/uboot-mtk-20230718-09eda825/common/main.c
@@ -63,15 +63,21 @@ void main_loop(void)
 			efi_launch_capsules();
 	}
 
+#ifdef CONFIG_HTTPD
 	if (env_get("failsafe") != NULL) {
 		env_set("failsafe", NULL);
 		env_save();
 
+#ifdef CONFIG_CMD_GL_BTN
 		led_control("led", "system_led", "on");
+#endif /* CONFIG_CMD_GL_BTN */
 		run_command("httpd", 0);
 	}
+#endif /* CONFIG_HTTPD */
 
+#ifdef CONFIG_CMD_GL_BTN
 	run_command("glbtn", 0);
+#endif
 
 	s = bootdelay_process();
 	if (cli_process_fdt(&s))

--- a/uboot-mtk-20230718-09eda825/common/main.c
+++ b/uboot-mtk-20230718-09eda825/common/main.c
@@ -13,13 +13,14 @@
 #include <command.h>
 #include <console.h>
 #include <env.h>
+#ifdef CONFIG_CMD_GL_BTN
+#include <glbtn.h>
+#endif
 #include <fdtdec.h>
 #include <init.h>
 #include <net.h>
 #include <version_string.h>
 #include <efi_loader.h>
-
-void led_control(const char *cmd, const char *name, const char *arg);
 
 static void run_preboot_environment_command(void)
 {

--- a/uboot-mtk-20230718-09eda825/include/glbtn.h
+++ b/uboot-mtk-20230718-09eda825/include/glbtn.h
@@ -1,0 +1,6 @@
+#ifndef _GLBTN_H_
+#define _GLBTN_H_
+
+void led_control(const char *cmd, const char *name, const char *arg);
+
+#endif


### PR DESCRIPTION
1. fix build without glbtn and httpd
2. add glbtn header