### PR TITLE
uboot-mtk-20230718-09eda825: minor fixes

### DIFF
--- a/uboot-mtk-20230718-09eda825/board/mediatek/common/bootmenu_mtd_legacy.c
+++ b/uboot-mtk-20230718-09eda825/board/mediatek/common/bootmenu_mtd_legacy.c
@@ -22,6 +22,7 @@
 #else
  #define UBI_VID_OFFSET QUOTE(CONFIG_ENV_UBI_VID_OFFSET)
 #endif
+int env_ubi_erase(void);
 #endif /* CONFIG_ENV_IS_IN_UBI */
 
 static struct mtd_info *get_mtd_part(const char *partname)
@@ -152,7 +153,7 @@ static int erase_env(void *priv, const struct data_part_entry *dpe,
 	if (ubi_part(CONFIG_ENV_UBI_PART, UBI_VID_OFFSET))
 		return -EIO;
 
-	ubi_remove_vol(CONFIG_ENV_UBI_VOLUME);
+	env_ubi_erase();
 	ubi_exit();
 #else
 	struct mtd_info *mtd;

--- a/uboot-mtk-20230718-09eda825/board/mediatek/common/failsafe.c
+++ b/uboot-mtk-20230718-09eda825/board/mediatek/common/failsafe.c
@@ -95,8 +95,10 @@ int failsafe_write_image(const void *data, size_t size, failsafe_fw_t fw)
 	if (!dpe)
 		return -ENODEV;
 
+#ifdef CONFIG_CMD_GL_BTN
 	led_control("led", "system_led", "off");
 	led_control("ledblink", "blink_led", "100");
+#endif
 	printf("\n");
 	cprintln(PROMPT, "*** Upgrading %s ***", dpe->name);
 	cprintln(PROMPT, "*** Data: %zd (0x%zx) bytes at 0x%08lx ***",
@@ -104,8 +106,10 @@ int failsafe_write_image(const void *data, size_t size, failsafe_fw_t fw)
 	printf("\n");
 
 	ret = dpe->write(dpe->priv, dpe, data, size);
+#ifdef CONFIG_CMD_GL_BTN
 	led_control("ledblink", "blink_led", "0");
 	led_control("led", "system_led", "on");
+#endif
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
- fix erase ubi env for legacy mtd bootmenu
- fix build without gl btn for failsafe