### PR TITLE
env: mtd: add the missing put_mtd_device()

### DIFF
--- a/uboot-mtk-20250711/env/mtd.c
+++ b/uboot-mtk-20250711/env/mtd.c
@@ -131,6 +131,8 @@ static int env_mtd_save(void)
 	puts("done\n");
 
 done:
+	put_mtd_device(mtd_env);
+
 	if (saved_buf)
 		free(saved_buf);
 
@@ -188,6 +190,8 @@ static int env_mtd_load(void)
 		gd->env_valid = ENV_VALID;
 
 out:
+	put_mtd_device(mtd_env);
+
 	free(buf);
 
 	return ret;
@@ -280,6 +284,8 @@ static int env_mtd_erase(void)
 	ret = 0;
 
 done:
+	put_mtd_device(mtd_env);
+
 	if (saved_buf)
 		free(saved_buf);
 


### PR DESCRIPTION
The mtd device is got in setup_mtd_device(), we must put the mtd
device before exiting the function to update the mtd use count.

ref [39ae954b04ef2fc4a8c14410379b663deb391fde](https://github.com/u-boot/u-boot/commit/39ae954b04ef2fc4a8c14410379b663deb391fde)