### PR TITLE
build.sh : return error on muilt layout defconfig not found

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,12 +27,6 @@ export CROSS_COMPILE="$TOOLCHAIN"
 
 ATF_CFG="${SOC}_${BOARD}_defconfig"
 UBOOT_CFG="${SOC}_${BOARD}_defconfig"
-for file in "$ATF_DIR/configs/$ATF_CFG" "$UBOOT_DIR/configs/$UBOOT_CFG"; do
-	if [ ! -f "$file" ]; then
-		echo "$file not found!"
-		exit 1
-	fi
-done
 
 if grep -Eq "CONFIG_FLASH_DEVICE_EMMC=y|_BOOT_DEVICE_EMMC=y" $ATF_DIR/configs/$ATF_CFG ; then
 	# No fixed-mtdparts or multilayout for EMMC
@@ -46,6 +40,14 @@ else
 		UBOOT_CFG="${SOC}_${BOARD}_multi_layout_defconfig"
 	fi
 fi
+
+for file in "$ATF_DIR/configs/$ATF_CFG" "$UBOOT_DIR/configs/$UBOOT_CFG"; do
+	if [ ! -f "$file" ]; then
+		echo "$file not found!"
+		exit 1
+	fi
+done
+
 echo "Building for: ${SOC}_${BOARD}, fixed-mtdparts: $fixedparts, multi-layout: $multilayout"
 echo "u-boot dir: $UBOOT_DIR"
 echo "atf dir: $ATF_DIR"


### PR DESCRIPTION
When the multi-layout configuration file is missing, the program may not exit but instead proceed to build non-existent devices.